### PR TITLE
Using https://... instead of relative URL for submoduling.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "FreeRTOS-Labs/Source/FreeRTOS-Plus-FAT"]
 	path = FreeRTOS-Labs/Source/FreeRTOS-Plus-FAT
-	url = ../Lab-Project-FreeRTOS-FAT.git
+	url = https://github.com/FreeRTOS/Lab-Project-FreeRTOS-FAT.git
 [submodule "FreeRTOS-Labs/Source/FreeRTOS-Plus-POSIX"]
 	path = FreeRTOS-Labs/Source/FreeRTOS-Plus-POSIX
-	url = ../Lab-Project-FreeRTOS-POSIX.git
+	url = https://github.com/FreeRTOS/Lab-Project-FreeRTOS-POSIX.git
 [submodule "FreeRTOS/Source"]
 	path = FreeRTOS/Source
-	url = ../FreeRTOS-Kernel.git
+	url = https://github.com/FreeRTOS/FreeRTOS-Kernel.git


### PR DESCRIPTION
**Why this PR is needed:**
When using relative URL, user cannot click through the submodule in web UI. So that user cannot jump to the git commit submodule is on. Git clone works regardless of relative URL or absolute. Though it's nice to provide consistent user experience, which is also suggested by Richard E. (Refer to https://github.com/FreeRTOS/FreeRTOS/pull/27)

**Test**
Clone command works as expected. 
