### PR TITLE
FreeRTOS_Plus_FAT_Demos: Fix a type bug on 64-bit platforms

### DIFF
--- a/FreeRTOS-Labs/Demo/Common/FreeRTOS_Plus_FAT_Demos/test/ff_stdio_tests_with_cwd.c
+++ b/FreeRTOS-Labs/Demo/Common/FreeRTOS_Plus_FAT_Demos/test/ff_stdio_tests_with_cwd.c
@@ -753,7 +753,7 @@ const size_t xSectorSize = 512U;
 const size_t xNumSectors = 3U;
 const size_t xOverwriteCheckBytes = 1U;
 const size_t xBufferSize = ( xSectorSize * xNumSectors ) + xSizeIncrement;
-size_t x, xSkippedBytes, x32BitValues;
+uint32_t x, xSkippedBytes, x32BitValues;
 char *pcBuffer;
 uint32_t *pulVerifyBuffer;
 uint32_t *pulVerifyValues;


### PR DESCRIPTION
x is assumed later in the code to be a 32-bit. There are some calcs doing
sizeof( x ) and comparing against 32-bit values, and those fail the configAsserts
on 64-bit builds since size_t is 64-bit on them.